### PR TITLE
docs: :memo: add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent instructions
+
+Before making any change in this repo, read [`CONTRIBUTING.md`](CONTRIBUTING.md) — it has the
+conventions that apply here.
+
+`CLAUDE.md` and `.github/copilot-instructions.md` are both symlinks to this file, so whichever
+one your tooling looks for, you end up here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Practical conventions for working in this repo — for human contributors and AI coding agents
+alike.
+
+## `docs/` are playbooks, not a journal
+
+Everything under [`docs/`](docs/) is an imperative runbook: a checklist meant to be followed
+step-by-step against live system state, written once and reused as-is. They are **not** a
+historical record of what this repo has already done, and shouldn't be edited to note "already
+done as of commit X" or similar — that turns a reusable playbook into a stale changelog entry
+instead of an instruction someone can actually follow again later.
+
+If a runbook's instructions stop applying (e.g. a package it references has since been removed
+elsewhere), fix the instructions so they're correct going forward. Don't annotate them with
+commit references or "resolved" notes.
+
+Decisions and the reasoning behind them belong in the relevant per-device README instead
+([`core/README.md`](core/README.md), [`router/README.md`](router/README.md),
+[`terminal/README.md`](terminal/README.md), [`handheld/README.md`](handheld/README.md)) — those
+are explicitly the tracked, opinionated record of what was chosen and why. `docs/` is not a
+substitute for that.
+
+## Commit and PR titles
+
+`<type>: <emoji> <lowercase description>` — gitmoji-style, e.g. `feat: :sparkles: add homelab
+plan content`, `fix: :bug: make clamonacc ignore firefox extensions`. Emoji shortcode or raw
+unicode are both fine. Only the title/subject line gets this treatment — commit bodies and PR
+descriptions stay normal prose.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,5 +25,5 @@ substitute for that.
 
 `<type>: <emoji> <lowercase description>` — gitmoji-style, e.g. `feat: :sparkles: add homelab
 plan content`, `fix: :bug: make clamonacc ignore firefox extensions`. Emoji shortcode or raw
-unicode are both fine. Only the title/subject line gets this treatment — commit bodies and PR
+Unicode are both fine. Only the title/subject line gets this treatment — commit bodies and PR
 descriptions stay normal prose.


### PR DESCRIPTION
## Summary
Prompted by accidentally turning `docs/aws-cleanup.md` and `docs/azure-cleanup.md` into a historical record (noting "already done as of commit X") instead of leaving them as reusable, imperative playbooks — reverted in #11, and codified here so it doesn't happen again.

- **`CONTRIBUTING.md`**: states the `docs/` convention explicitly (playbooks, not a journal — decisions/rationale belong in the per-device READMEs instead), plus the gitmoji-style commit/PR title format that's already visible throughout this repo's history but was never written down anywhere a contributor or agent could find it.
- **`AGENTS.md`**: tells any agent working in this repo to read `CONTRIBUTING.md` first.
- **`CLAUDE.md`** and **`.github/copilot-instructions.md`** are both real symlinks to `AGENTS.md` — one source of truth instead of three files to keep in sync by hand.

## Test plan
- [ ] `cat CLAUDE.md` and `cat .github/copilot-instructions.md` both resolve to `AGENTS.md`'s content
- [ ] `git ls-files -s CLAUDE.md .github/copilot-instructions.md` shows mode `120000` (symlink) for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUrkmnBBJsaMLkxDv34kLL