### PR TITLE
docs: :memo: confirm Open WebUI over LibreChat and AnythingLLM

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -516,6 +516,27 @@ never reachable outside the tailnet either way.
 **Checked, not a blocker:** Open WebUI's 2025 relicensing added a branding-retention clause that
 only applies at 50+ active users — irrelevant at household scale.
 
+**Considered and not adopted, named as real trade-offs:**
+- **LibreChat** — comparable scale and activity, and a genuinely cleaner license (plain MIT, no
+  branding-retention clause at all) — but requires **MongoDB**, a third database engine on the
+  compute core for no other reason than this one service, when Open WebUI can run on the
+  Postgres already needed for Letta's memory. The cleaner license didn't outweigh that
+  operational-complexity cost.
+- **AnythingLLM** — equally huge, clean MIT license, and genuinely the most mature RAG/
+  document-chat implementation of the three (its original design centre, not bolted on). Two
+  things ruled it out: it's a heavier tool than "just chat" needs (built around multi-workspace
+  RAG, more scope than this use case calls for), and its speech-to-text defaults to the
+  browser's own Web Speech API with no self-hosted alternative — in most browsers that routes
+  audio through a third-party cloud service (Google, in Chrome), a real conflict with
+  `motivation.md`'s privacy-first principle if voice-in-chat-UI is ever turned on. Open WebUI's
+  STT and TTS can both point at a self-hosted OpenAI-compatible endpoint instead, so it doesn't
+  force that trade-off even though voice stays off by default (see
+  [Notifications](#notifications-unified-via-home-assistant-across-aegis-crewai-and-openhands)).
+- Checked and found genuinely neutral either way, not deciding factors: AEGIS's tool-call
+  guardrails reach both equally (its MCP/HTTP proxy is framework-agnostic, not tied to one
+  product), and both tools' own built-in agent/scheduling features get turned off in favour of
+  CrewAI regardless of which one is used.
+
 ### Notifications: unified via Home Assistant, across AEGIS, CrewAI, and OpenHands
 
 **Decided:** every "a human needs to look at this" moment across the agent stack routes through


### PR DESCRIPTION
## Summary
Closes out the deep-dive primary-interface comparison with a final decision, recorded in `core/README.md`'s "Primary interface" section:

- **LibreChat** — comparable scale/activity and a genuinely cleaner MIT license than Open WebUI's, but requires **MongoDB**, a third database engine on the compute core for no other reason than this one service, when Open WebUI can share the Postgres already needed for Letta's memory. Ruled out on operational complexity, not merit.
- **AnythingLLM** — equally huge, clean MIT license, and the most mature RAG/document-chat implementation of the three. Ruled out on two things: heavier scope than "just chat" needs (multi-workspace RAG-first design), and its speech-to-text defaults to the browser's own Web Speech API with no self-hosted alternative — a real privacy-principle conflict if voice-in-chat-UI is ever turned on, since Open WebUI's STT/TTS can both point at a self-hosted endpoint instead.
- Named explicitly as neutral, not deciding factors either way: AEGIS's guardrail reach (framework-agnostic, covers both equally) and the CrewAI built-in-agent-feature overlap (both get turned off regardless of which chat UI wins).

## Test plan
- [ ] Read the updated "Primary interface" section end-to-end to confirm the reasoning reads cleanly against the rest of the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUrkmnBBJsaMLkxDv34kLL