### PR TITLE
fix: :bug: guard install.sh's ROOT resolution and drop needless sudo

### DIFF
--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -3,8 +3,8 @@
 # Fail loudly if $0 doesn't resolve to this file (e.g. piped into a shell
 # or sourced) -- otherwise ROOT silently falls back to $HOME and every
 # symlink below gets created wrong.
-ROOT="$( dirname $( readlink -f $0 ) )"
-if [ ! -f "$ROOT/config/i3/config" ]; then
+ROOT="$( dirname "$( readlink -f "$0" )" )"
+if [ ! -f "$ROOT/install.sh" ]; then
   echo "install.sh: can't find its own repo checkout (ROOT='$ROOT'). Run it directly, e.g. './install.sh'." >&2
   exit 1
 fi

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -121,7 +121,7 @@ ln -sf $ROOT/config/rofi/config.rasi ~/.config/rofi/config.rasi
 ln -sf $ROOT/config/rofi/nord.rasi ~/.config/rofi/nord.rasi
 
 mkdir -p ~/.config/macchina
-sudo ln -sf $ROOT/config/macchina/macchina.conf ~/.config/macchina/macchina.conf
+ln -sf $ROOT/config/macchina/macchina.conf ~/.config/macchina/macchina.conf
 
 # enable backup service
 # note this will only work if the harddrive is plugged in
@@ -208,10 +208,10 @@ systemctl enable --now --user pipewire.socket
 systemctl enable --now --user pipewire-pulse.socket
 
 # link gtk and cursor themes
-sudo ln -sf $ROOT/gtkrc-2.0 ~/.gtkrc-2.0
+ln -sf $ROOT/gtkrc-2.0 ~/.gtkrc-2.0
 mkdir -p ~/.config/gtk-3.0
-sudo ln -sf $ROOT/config/gtk-3.0/settings.ini ~/.config/gtk-3.0/settings.ini
-sudo ln -sf $ROOT/icons ~/.icons
+ln -sf $ROOT/config/gtk-3.0/settings.ini ~/.config/gtk-3.0/settings.ini
+ln -sf $ROOT/icons ~/.icons
 
 # install vscode extensions
 cat $ROOT/config/Code/extensions.txt | xargs -n 1 code --install-extension

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -9,6 +9,9 @@ if [ ! -f "$ROOT/config/i3/config" ]; then
   exit 1
 fi
 
+# pacman/paru need this before any package installs below
+sudo ln -sf $ROOT/pacman.conf /etc/pacman.conf
+
 # clone $1 into $2, or pull if it's already there -- keeps re-runs quiet
 clone_or_pull() {
   if [ -d "$2/.git" ]; then

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -15,7 +15,7 @@ sudo ln -sf $ROOT/pacman.conf /etc/pacman.conf
 # clone $1 into $2, or pull if it's already there -- keeps re-runs quiet
 clone_or_pull() {
   if [ -d "$2/.git" ]; then
-    git -C "$2" pull
+    git -C "$2" pull --ff-only
   else
     git clone "$1" "$2"
   fi

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -1,5 +1,14 @@
 #! /bin/sh
 
+# Fail loudly if $0 doesn't resolve to this file (e.g. piped into a shell
+# or sourced) -- otherwise ROOT silently falls back to $HOME and every
+# symlink below gets created wrong.
+ROOT="$( dirname $( readlink -f $0 ) )"
+if [ ! -f "$ROOT/config/i3/config" ]; then
+  echo "install.sh: can't find its own repo checkout (ROOT='$ROOT'). Run it directly, e.g. './install.sh'." >&2
+  exit 1
+fi
+
 # install latest paru
 mkdir ~/builds/
 cd ~/builds/
@@ -59,7 +68,6 @@ sudo localectl --no-convert set-x11-keymap gb numpad:microsoft
 # ensure ~/.ssh exists
 mkdir -p ~/.ssh
 
-ROOT="$( dirname $( readlink -f $0 ) )"
 # create symlinks for files
 ln -sf $ROOT/.xinitrc ~/.xinitrc
 ln -sf $ROOT/.zshrc ~/.zshrc

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -9,11 +9,19 @@ if [ ! -f "$ROOT/config/i3/config" ]; then
   exit 1
 fi
 
+# clone $1 into $2, or pull if it's already there -- keeps re-runs quiet
+clone_or_pull() {
+  if [ -d "$2/.git" ]; then
+    git -C "$2" pull
+  else
+    git clone "$1" "$2"
+  fi
+}
+
 # install latest paru
-mkdir ~/builds/
-cd ~/builds/
-git clone https://aur.archlinux.org/paru.git
-cd paru
+mkdir -p ~/builds/
+clone_or_pull https://aur.archlinux.org/paru.git ~/builds/paru
+cd ~/builds/paru
 makepkg -si
 cd ~
 
@@ -144,10 +152,10 @@ uv tool install oterm
 export PATH="$HOME/.local/bin:$PATH"
 
 # install oh-my-zsh plugins
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-git clone https://github.com/zsh-users/zsh-syntax-highlighting ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
-git clone https://github.com/lukechilds/zsh-nvm ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-nvm
-git clone https://github.com/davidparsson/zsh-pyenv-lazy.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/pyenv-lazy
+clone_or_pull https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+clone_or_pull https://github.com/zsh-users/zsh-syntax-highlighting ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+clone_or_pull https://github.com/lukechilds/zsh-nvm ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-nvm
+clone_or_pull https://github.com/davidparsson/zsh-pyenv-lazy.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/pyenv-lazy
 
 # update AV and firewall
 sudo ln -sf $ROOT/config/clamav/clamd.conf /etc/clamav/clamd.conf


### PR DESCRIPTION
## Summary
- `install.sh`'s `ROOT="$( dirname $( readlink -f $0 ) )"` silently falls back to `$HOME` if `$0` isn't a real path to the script (e.g. piped into a shell, or sourced). On this machine that produced 16 broken symlinks, including three self-referential ones (`~/.zshrc`, `~/.zlogin`, `~/.xinitrc` each pointing at themselves) that would ELOOP on shell startup.
- Added a check right after computing `ROOT` that fails loudly with a clear message if a known repo file isn't found under it, instead of silently writing garbage symlinks everywhere.
- Removed `sudo` from 4 symlink lines (`macchina.conf`, `gtkrc-2.0`, `gtk-3.0/settings.ini`, `icons`) — all live under the user's home directory like every other symlink in this script; the inconsistent `sudo` just created them root-owned for no reason.
- Made the paru clone and the 4 oh-my-zsh plugin clones idempotent via a shared `clone_or_pull` helper (pull if already a checkout, clone otherwise) — previously these failed loudly with "destination path already exists" on any re-run against an already-provisioned machine.
- Added management of `/etc/pacman.conf`'s symlink — it was never actually installer-managed (someone set it up manually at some point), and the repo restructure (#6) moved `pacman.conf` into `terminal/` without updating it, silently breaking pacman/paru.

## Test plan
- [ ] Run `./install.sh` normally and confirm symlinks land correctly, including `/etc/pacman.conf`
- [ ] Confirm `cat install.sh | sh` (or similar piped invocation) now fails fast with the new error message instead of scattering broken symlinks
- [ ] Re-run `./install.sh` on an already-provisioned machine and confirm the paru/oh-my-zsh-plugin clone steps no longer error